### PR TITLE
Add debug info to scripts

### DIFF
--- a/R/filter_and_trim_functions.R
+++ b/R/filter_and_trim_functions.R
@@ -73,9 +73,9 @@ condor_filter_trim <- function(
       str_c("queue_file       = ", trim_queue_file),
       str_c("param_file       = ", trim_param_file),
       str_c("outdir           = ", trim_outdir),
-      "output           = $(outdir)/out/dada2_filter_trim_$(sample_name).$(cluster).$(process).out",
-      "error            = $(outdir)/err/dada2_filter_trim_$(sample_name).$(cluster).$(process).err",
-      "log              = $(outdir)/log/dada2_filter_trim_$(sample_name).$(cluster).$(process).log",
+      "output           = $(outdir)/out/dada2_filter_trim_$(sample).$(cluster).$(process).out",
+      "error            = $(outdir)/err/dada2_filter_trim_$(sample).$(cluster).$(process).err",
+      "log              = $(outdir)/log/dada2_filter_trim_$(sample).$(cluster).$(process).log",
       "queue sample, fastq1, fastq2 from $(queue_file)"),file_connection)
 
   close(file_connection)

--- a/R/merge_pairs_functions.R
+++ b/R/merge_pairs_functions.R
@@ -73,9 +73,9 @@ condor_merge_pairs <- function(
       str_c("param_file       = ", merge_param_file),
       str_c("outdir           = ", merge_outdir),
       str_c("queue_file       = ", merge_queue_file),
-      "output           = $(outdir)/out/dada2_merge_pairs_$(sample_name).$(cluster).$(process).out",
-      "error            = $(outdir)/err/dada2_merge_pairs_$(sample_name).$(cluster).$(process).err",
-      "log              = $(outdir)/log/dada2_merge_pairs_$(sample_name).$(cluster).$(process).log",
+      "output           = $(outdir)/out/dada2_merge_pairs_$(sample).$(cluster).$(process).out",
+      "error            = $(outdir)/err/dada2_merge_pairs_$(sample).$(cluster).$(process).err",
+      "log              = $(outdir)/log/dada2_merge_pairs_$(sample).$(cluster).$(process).log",
       str_c("rates1           = ", error_rate_files[1]),
       str_c("rates2           = ", error_rate_files[2]),
       "queue sample, fastq1, fastq2 from $(queue_file)"), file_connection)

--- a/inst/scripts/filter_and_trim_pairs.R
+++ b/inst/scripts/filter_and_trim_pairs.R
@@ -79,7 +79,7 @@ message("filter and trim for files:")
 message("fastq1: ", opt$fastq1)
 message("fastq2: ", opt$fastq2)
 
-message("output files")
+message("output files will be created:")
 message("filtered fastq1: ", fastq1_filtered)
 message("filtered fastq2: ", fastq2_filtered)
 

--- a/inst/scripts/filter_and_trim_pairs.R
+++ b/inst/scripts/filter_and_trim_pairs.R
@@ -9,6 +9,11 @@
 ## or there is not json file, then the code will use the
 ## dada2's default parameters.
 
+
+info=Sys.info();
+message(paste0(names(info)," : ",info,"\n"))
+
+
 library(optparse)
 
 opt_list <- list(
@@ -21,7 +26,7 @@ opt_list <- list(
               help = "Location of the R2 fastq.gz file"),
   make_option("--param_file", action = "store_true", type = "character",
               help = "Location of the parameter file in json format, if not provided
-        	the script will do dada2::filterAndTrim with all the default parameters"),
+          the script will do dada2::filterAndTrim with all the default parameters"),
   make_option("--outdir", action = "store_true", type = "character",
               default = tempdir(),
               help = "Location of the output directory"),
@@ -105,4 +110,8 @@ if(!file.exists(out_file)){
 
   saveRDS(summary_out, file = out_file)
   message("Done! Summary file saved at ", out_file)
+} else {
+  message("Existing summary file ", out_file, " found. Delete that file if you want to rerun sample ", opt$sample_name, ".")
 }
+
+

--- a/inst/scripts/label_taxa.R
+++ b/inst/scripts/label_taxa.R
@@ -1,5 +1,10 @@
 #!/usr/bin/env Rscript
 
+
+info=Sys.info();
+message(paste0(names(info)," : ",info,"\n"))
+
+
 library(optparse,quietly = TRUE)
 
 optList <-  list(

--- a/inst/scripts/learn_error_rates.R
+++ b/inst/scripts/learn_error_rates.R
@@ -10,6 +10,11 @@
 ## or there is not json file, then the code will use the
 ## dada2's default parameters.
 
+
+info=Sys.info();
+message(paste0(names(info)," : ",info,"\n"))
+
+
 library(optparse)
 
 opt_list <- list(

--- a/inst/scripts/make_sequence_table.R
+++ b/inst/scripts/make_sequence_table.R
@@ -12,6 +12,10 @@
 ## The first two methods barely require a parameter, while the third one
 ## requires a whole set of parameters that tune the behaviour of the matches reads
 
+
+info=Sys.info();
+message(paste0(names(info)," : ",info,"\n"))
+
 library(optparse)
 
 opt_list <- list(

--- a/inst/scripts/merge_pairs.R
+++ b/inst/scripts/merge_pairs.R
@@ -12,6 +12,11 @@
 ## The first two methods barely require a parameter, while the third one
 ## requires a whole set of parameters that tune the behaviour of the matches reads
 
+
+info=Sys.info();
+message(paste0(names(info)," : ",info,"\n"))
+
+
 library(optparse)
 
 opt_list <- list(

--- a/inst/scripts/prevalence_analysis.R
+++ b/inst/scripts/prevalence_analysis.R
@@ -1,4 +1,9 @@
 #!/usr/bin/env Rscript
+
+info=Sys.info();
+message(paste0(names(info)," : ",info,"\n"))
+
+
 library(optparse)
 
 opt_list <- list(

--- a/inst/scripts/remove_chimeras.R
+++ b/inst/scripts/remove_chimeras.R
@@ -1,5 +1,9 @@
 #!/usr/bin/env Rscript
 
+
+info=Sys.info();
+message(paste0(names(info)," : ",info,"\n"))
+
 library(optparse,quietly = TRUE)
 
 optList <-  list(

--- a/inst/scripts/sourcetracker_run.R
+++ b/inst/scripts/sourcetracker_run.R
@@ -1,5 +1,8 @@
 #!/usr/bin/env Rscript
 
+info=Sys.info();
+message(paste0(names(info)," : ",info,"\n"))
+
 ## wrapper for sourcetracker run
 
 library(optparse)

--- a/inst/scripts/summarize_nreads.R
+++ b/inst/scripts/summarize_nreads.R
@@ -1,5 +1,9 @@
 #!/usr/bin/env Rscript
 
+
+info=Sys.info();
+message(paste0(names(info)," : ",info,"\n"))
+
 library(optparse,quietly = TRUE)
 
 optList <-  list(


### PR DESCRIPTION
I added a printout of Sys.info to each script in inst/scripts/. This will print out the host name of the machine it's running on, the user who is running it, and some other information. This can be useful for debugging condor issues. eg, it's useful to know if it's running on a machine that doesn't have access to our file system.

I also added a message to filter_trim_pairs to notify the user if the summary file already exists. Currently if that file already exists, the script aborts and doesn't do any filtering; this is useful to be informed about.

I also edited some of the condor script generation code. "sample_name" had been referred to as a variable, but it should be "sample".