### PR TITLE
Updated option help text in make_sequence_table, report missing files

### DIFF
--- a/inst/scripts/extract_fasta_before_kraken.R
+++ b/inst/scripts/extract_fasta_before_kraken.R
@@ -1,0 +1,62 @@
+#!/usr/bin/env Rscript
+
+#' Extract fasta file from an ASV table file (post chimera removal). 
+#' We need to provide kraken2 the sequences in fasta format.
+
+library(magrittr)
+library(tidyverse)
+library(seqinr)
+library(optparse)
+
+
+info=Sys.info();
+message(paste0(names(info)," : ",info,"\n"))
+
+
+library(optparse)
+opt_list <- list(
+  make_option("--asv_file", action = "store_true", type = "character",
+              help = "Name of input ASV sequence table (after chimera filter)."),
+  make_option("--outdir", action = "store_true", type = "character",
+              help = "Location of the output directory (top level)"),
+  make_option("--prefix", action = "store_true", type = "character",
+              help = "Prefix for output filename (will be {outdir}/fasta/{prefix}.fna")
+)
+opt <- parse_args(OptionParser(option_list = opt_list))
+
+### get asv tables after removing chimeras
+
+base_dr <- opt$outdir
+my_prefix <- opt$prefix
+asv_file <- opt$asv_file
+
+# check file, directory existence 
+fasta_dir <- file.path(base_dr, "fasta")
+out_file <- file.path(fasta_dir, sprintf("%s.fna", my_prefix))
+
+if (!file.exists(out_file)) {
+  message("Output fasta file ", out_file, " already exists. Remove if you want to run again.")
+} else if (!file.exists(asv_file)) {
+  message("Input sequence table ", asv_file, " does not exist.")
+} else {  
+  my_asv <- asv_file %>%
+    readRDS()
+  
+  # get sequences from the asv table
+  get_sequences <- function(asv) {
+  	seqs <- colnames(asv)
+    seqs <- str_split(seqs, pattern = "")
+  	names(seqs) <- str_c("asv", seq_along(seqs), sep = "_")
+  	seqs
+  }
+  sequences <- get_sequences(my_asv)
+  
+  # make the fasta dir and write output if we got this far
+  dir.create(fasta_dir, showWarnings = FALSE)
+  seqinr::write.fasta(
+    sequences,
+    names(sequences),
+    out_file, nbchar = 500)
+  
+  message("Done! Wrote fasta file ", out_file)
+}

--- a/inst/scripts/extract_fasta_before_kraken.R
+++ b/inst/scripts/extract_fasta_before_kraken.R
@@ -1,7 +1,8 @@
 #!/usr/bin/env Rscript
 
 #' Extract fasta file from an ASV table file (post chimera removal). 
-#' We need to provide kraken2 the sequences in fasta format.
+#' (We need to provide kraken2 the sequences in fasta format.)
+#' Puts the resulting *fna file in {outdir}/fasta/
 
 library(magrittr)
 library(tidyverse)

--- a/inst/scripts/make_sequence_table.R
+++ b/inst/scripts/make_sequence_table.R
@@ -64,7 +64,7 @@ all_files %>%
     filter(!has_pairs) %>%
     select(sample_name, out_file) %>%
     deframe() %>%
-    walk2(names(.), .f=~message("Dropping sample ", .x, ". No merged pairs file ", .y))
+    walk2(names(.), .f=~message("Dropping sample ", .y, ". No merged pairs file ", .x))
 
 all_files %<>%
   filter(has_pairs) %>%

--- a/inst/scripts/remove_chimeras.R
+++ b/inst/scripts/remove_chimeras.R
@@ -80,8 +80,8 @@ if(!file.exists(out_file)){
     multithread = TRUE)
 
   saveRDS(asv_table,out_file)
-
-
+} else {
+  message("Output file ", out_file, " already exists. If you want to rerun this script, delete that file first.")
 }
 
 


### PR DESCRIPTION
1.  I updated the "queue_file" help text to refer to the sample queue file

2. The first time I ran it, it failed and went to H state because it tried to read merged_pair files for samples that had been completely filtered out earlier in the pipeline. I propose that we flag those samples, report them with message(), and then remove them when we actually construct the seqtable. 

Would you check whether I invoked walk2 in the right style? It doesn't work if I pipe a tibble directly into it. I saw "deframe" on someone's stackoverflow post, but I don't know if it's Best Practices to use it this way.

Thanks!