### PR TITLE
Update summary script (address this after the update_summary_script request)

### DIFF
--- a/R/quality_control_diagnostics.R
+++ b/R/quality_control_diagnostics.R
@@ -13,52 +13,64 @@ NULL
 ##' @param outprefix prefix used in the final ASV table
 ##' @param outdir names of the output directory where the results are saved
 ##' @param cores number of cpus used to run the process
+##' @return the summary
 ##' @export
 summarize_number_reads <- function(reads_file,outprefix,outdir,cores)
 {
-  `.` <- R1 <- R2 <- NULL
+    `.` <- R1 <- R2 <- NULL
   name <- fold_change <- reads.out <- reads.in <- reads.merged_pairs <- NULL
   reads.asv_table <- NULL
-
+  
   future::plan(future::multiprocess,workers = cores)
-
+  
   stopifnot(
     file.exists(reads_file),
     dir.exists(outdir))
-
+  
   ### read input file, i.e. the 3 column file
   input_files = read_csv(reads_file,col_names = FALSE) %>% set_names(c("name","R1","R2"))
-
+  
   input_files %<>%
     mutate(
       summ = file.path(outdir,"filter_fastq_summary",paste0(name,"_trim_summary.rds")) %>%
         furrr::future_map(readRDS)) %>%
     tidyr::unnest() %>%
     select(-fold_change)
-
+  
+  # For which do we have merged pair summary files? Set reads.merged_pairs to NA if missing.
   input_files %<>% select(-R1,-R2) %>%
     mutate(
       reads.merged_pairs = file.path(outdir,"merged_pairs",
-                                   paste0(name,"_merged_pairs.rds")) %>%
-        furrr::future_map(readRDS) %>%
-        furrr::future_map_dbl( ~ sum(.$abundance)))
-
+                                     paste0(name,"_merged_pairs.rds")))
+  nomerged <- input_files %>%
+    filter(!file.exists(reads.merged_pairs)) %>%
+    mutate(reads.merged_pairs=NA)
+  yesmerged <- input_files %>% 
+    filter(file.exists(reads.merged_pairs)) %>%
+    mutate(reads.merged_pairs=reads.merged_pairs %>% furrr::future_map(readRDS) %>% furrr::future_map_dbl( ~ sum(.$abundance)))
+  input_files <- bind_rows(nomerged, yesmerged) %>% arrange(name)
+  
+  
   asv_table <- readRDS(file.path(outdir,"ASV_tables",paste0(outprefix,"_sequence_table.rds")))
-
+  
   asv_table %<>%
-    {
-      rs = rowSums(.)
-      tibble(
-        name = names(rs),
-        reads.asv_table = rs)}
-
-  input_files %<>% inner_join(asv_table,by = "name")
-  input_files %>%
+  {
+    rs = rowSums(.)
+    tibble(
+      name = names(rs),
+      reads.asv_table = rs)}
+  
+  #input_files %<>% inner_join(asv_table,by = "name")
+  # left join will maintain lost samples, inner join will not
+  input_files %<>% left_join(asv_table,by = "name")
+  input_files %<>%
+    mutate(reads.asv_table=ifelse(reads.merged_pairs==0, 0, reads.asv_table)) %>%
     mutate(
       perc.out = reads.out / reads.in,
       perc.merged_pairs = reads.merged_pairs / reads.in,
       perc.asv_table = reads.asv_table / reads.in  )
 
+  return(input_files)
 }
 
 
@@ -72,14 +84,10 @@ plot_abundance_per_step <- function(nreads_summary, summary_fun = median, relati
 {
   name <- step <- sample <- NULL
   if(relative){
-
     nreads_summary <- select(nreads_summary,name,sample,contains("perc"))
     nreads_summary <- mutate(nreads_summary,perc.in = 1)
-
-  }else{
-
+  } else{
     nreads_summary <- select(nreads_summary,name,sample,contains("reads"))
-
   }
 
   nreads_summary <- tidyr::gather(nreads_summary,step,value,-name,-sample)

--- a/inst/scripts/extract_fasta_before_kraken.R
+++ b/inst/scripts/extract_fasta_before_kraken.R
@@ -1,0 +1,62 @@
+#!/usr/bin/env Rscript
+
+#' Extract fasta file from an ASV table file (post chimera removal). 
+#' We need to provide kraken2 the sequences in fasta format.
+
+library(magrittr)
+library(tidyverse)
+library(seqinr)
+library(optparse)
+
+
+info=Sys.info();
+message(paste0(names(info)," : ",info,"\n"))
+
+
+library(optparse)
+opt_list <- list(
+  make_option("--asv_file", action = "store_true", type = "character",
+              help = "Name of input ASV sequence table (after chimera filter)."),
+  make_option("--outdir", action = "store_true", type = "character",
+              help = "Location of the output directory (top level)"),
+  make_option("--prefix", action = "store_true", type = "character",
+              help = "Prefix for output filename (will be {outdir}/fasta/{prefix}.fna")
+)
+opt <- parse_args(OptionParser(option_list = opt_list))
+
+### get asv tables after removing chimeras
+
+base_dr <- opt$outdir
+my_prefix <- opt$prefix
+asv_file <- opt$asv_file
+
+# check file, directory existence 
+fasta_dir <- file.path(base_dr, "fasta")
+out_file <- file.path(fasta_dir, sprintf("%s.fna", my_prefix))
+
+if (!file.exists(out_file)) {
+  message("Output fasta file ", out_file, " already exists. Remove if you want to run again.")
+} else if (!file.exists(asv_file)) {
+  message("Input sequence table ", asv_file, " does not exist.")
+} else {  
+  my_asv <- asv_file %>%
+    readRDS()
+  
+  # get sequences from the asv table
+  get_sequences <- function(asv) {
+  	seqs <- colnames(asv)
+    seqs <- str_split(seqs, pattern = "")
+  	names(seqs) <- str_c("asv", seq_along(seqs), sep = "_")
+  	seqs
+  }
+  sequences <- get_sequences(my_asv)
+  
+  # make the fasta dir and write output if we got this far
+  dir.create(fasta_dir, showWarnings = FALSE)
+  seqinr::write.fasta(
+    sequences,
+    names(sequences),
+    out_file, nbchar = 500)
+  
+  message("Done! Wrote fasta file ", out_file)
+}

--- a/inst/scripts/extract_fasta_before_kraken.R
+++ b/inst/scripts/extract_fasta_before_kraken.R
@@ -1,7 +1,8 @@
 #!/usr/bin/env Rscript
 
 #' Extract fasta file from an ASV table file (post chimera removal). 
-#' We need to provide kraken2 the sequences in fasta format.
+#' (We need to provide kraken2 the sequences in fasta format.)
+#' Puts the resulting *fna file in {outdir}/fasta/
 
 library(magrittr)
 library(tidyverse)

--- a/inst/scripts/make_sequence_table.R
+++ b/inst/scripts/make_sequence_table.R
@@ -64,7 +64,7 @@ all_files %>%
     filter(!has_pairs) %>%
     select(sample_name, out_file) %>%
     deframe() %>%
-    walk2(names(.), .f=~message("Dropping sample ", .x, ". No merged pairs file ", .y))
+    walk2(names(.), .f=~message("Dropping sample ", .y, ". No merged pairs file ", .x))
 
 all_files %<>%
   filter(has_pairs) %>%

--- a/inst/scripts/remove_chimeras.R
+++ b/inst/scripts/remove_chimeras.R
@@ -80,8 +80,8 @@ if(!file.exists(out_file)){
     multithread = TRUE)
 
   saveRDS(asv_table,out_file)
-
-
+} else {
+  message("Output file ", out_file, " already exists. If you want to rerun this script, delete that file first.")
 }
 
 

--- a/inst/scripts/summarize_nreads.R
+++ b/inst/scripts/summarize_nreads.R
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-
+# Summarize numbers of reads per step, makes some plots
 
 info=Sys.info();
 message(paste0(names(info)," : ",info,"\n"))
@@ -7,36 +7,64 @@ message(paste0(names(info)," : ",info,"\n"))
 library(optparse,quietly = TRUE)
 
 optList <-  list(
-  make_option("--reads_file", action = "store_true", type = "character",
-              help = "File with the name of the sequence files"),
-  make_option("--outprefix", action = "store_true", type = "character",
+  make_option("--queue_file", action = "store_true", type = "character",
+              help = "Three-column file with the names of samples and input fastqs"),
+  make_option("--prefix", action = "store_true", type = "character",
               default = "dada2",
-              help = "Name of the output file with the labelled ASVs after
-                    	removing the bimeras, the full file name will
-        				be {outdir}/summary/{outprefix}_nreads.rds"),
+              help = "Prefix of the output ASV table sans chimeras. Will also be used in output file name
+                be {outdir}/summary/{outprefix}_nreads.rds"),
   make_option("--outdir", action = "store_true", type = "character",
               default = tempdir(),
-              help = "Location of the output directory"),
+              help = "Top level of output directory (top of file structure for this run)"),
   make_option("--cores", action = "store_true", type = "numeric",
               default = 4,
               help = "Number of parallel cpus to use"))
 
-
 opt <- parse_args(OptionParser(option_list = optList))
 
-out_file = file.path(opt$outdir,"summary",paste0(opt$outprefix,"_nreads.rds"))
+opt=list()
+opt$queue_file="run/sample_table.csv"
+opt$prefix="stool_vg_2018"
+opt$outdir="./run"
+opt$cores=4
 
+out_file = file.path(opt$outdir,"summary",paste0(opt$prefix,"_nreads.rds"))
+
+# condor job will hold if we stop
 stopifnot(
-  file.exists(opt$reads_file),
+  file.exists(opt$queue_file),
   dir.exists(opt$outdir))
-
 
 library(magrittr)
 library(tidyverse)
 library(furrr)
 library(microbiome.onglab)
 
-input_files <- summarize_number_reads(opt$reads_file, optoutprefix,
-                                      opt$outdir,opt$cores)
 
+input_files <- summarize_number_reads(opt$queue_file, opt$prefix,
+                                      opt$outdir,opt$cores)
 input_files %>% saveRDS(out_file)
+
+summary_absolute <- microbiome.onglab::plot_abundance_per_step(input_files)
+summary_relative <- microbiome.onglab::plot_abundance_per_step(input_files, relative = TRUE)
+
+
+figdir=file.path(opt$outdir,"figs")
+if (!dir.exists(figdir)) dir.create(figdir)
+
+abs_fname=file.path( figdir, sprintf("%s_abu_per_step.png", opt$prefix))
+rel_fname=file.path( figdir, sprintf("%s_rel_abu_per_step.png", opt$prefix))
+ggsave(
+  filename = abs_fname,
+  plot = summary_absolute,
+  width = 6,
+  height = 4,
+  units = "in")
+ggsave(
+  filename = rel_fname,
+  plot = summary_relative,
+  width = 6,
+  height = 4,
+  units = "in")
+
+message("Saved summary to ", out_file, ", ", abs_fname, ", ", rel_fname)

--- a/inst/scripts/summarize_nreads.R
+++ b/inst/scripts/summarize_nreads.R
@@ -22,11 +22,11 @@ optList <-  list(
 
 opt <- parse_args(OptionParser(option_list = optList))
 
-opt=list()
-opt$queue_file="run/sample_table.csv"
-opt$prefix="stool_vg_2018"
-opt$outdir="./run"
-opt$cores=4
+#opt=list()
+#opt$queue_file="run/sample_table.csv"
+#opt$prefix="stool_vg_2018"
+#opt$outdir="./run"
+#opt$cores=4
 
 out_file = file.path(opt$outdir,"summary",paste0(opt$prefix,"_nreads.rds"))
 


### PR DESCRIPTION
1. Updated the summarize_nreads.R script to also make plots of absolute and relative abundance per step.
2. Updated summarize_number_reads to gracefully handle samples that were completely lost at some step of the pipeline. The absolute reads will be 0 from that point on. 

For samples that were in the queue file but had no fastq file (eg if we pulled the queue file from the sequencing manifest and some samples had no reads), we'll have NaN for the relative values.